### PR TITLE
September release PDF Embed API

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,7 +2,7 @@
 name: Github Pages
 on:
   push:
-    branches: [main]
+    branches: [hotfix]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/src/pages/overview/pdf-embed-api/releasenotes.md
+++ b/src/pages/overview/pdf-embed-api/releasenotes.md
@@ -12,8 +12,8 @@ the changes below for each release.
 
 | Change | Description                                                            |
 | ------ | ---------------------------------------------------------------------- |
-| Bug fix | Fixed PREVIEW_RENDERING_FAILED error for large PDF files.
-| Bug fix | Fixed Search button accessibility issue.
+| Bug fix | Fixed PREVIEW_RENDERING_FAILED error for large PDF files.             |
+| Bug fix | Fixed Search button accessibility issue.                              |
 
 ### July, 2023
 


### PR DESCRIPTION
PDF Embed API September 2023 release notes.
Changes:

Fixed PREVIEW_RENDERING_FAILED error for large PDF files.
Fixed search button accessibility issue.