### PR TITLE
added release notes for java sdk 3.5.1

### DIFF
--- a/src/pages/overview/document-generation-api/quickstarts/java/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/java/index.md
@@ -63,7 +63,7 @@ To complete this guide, you will need:
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
   </properties>
 
   <dependencies>

--- a/src/pages/overview/pdf-accessibility-auto-tag-api/gettingstarted.md
+++ b/src/pages/overview/pdf-accessibility-auto-tag-api/gettingstarted.md
@@ -226,7 +226,7 @@ For security reasons you may wish to confirm the installer's authenticity. To do
 4.  Verify the hash you generated matches the value in the .sha1 file.
 
 ```
-deedd2b91d988fd2300fee47a90069ccc4c51012
+c0bc2ec0eb15dd43d014bd885b3833539f103cf2
 ```
 
 #### Logging

--- a/src/pages/overview/pdf-accessibility-auto-tag-api/quickstarts/java/index.md
+++ b/src/pages/overview/pdf-accessibility-auto-tag-api/quickstarts/java/index.md
@@ -63,7 +63,7 @@ To complete this guide, you will need:
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
   </properties>
 
   <dependencies>

--- a/src/pages/overview/pdf-electronic-seal-api/gettingstarted.md
+++ b/src/pages/overview/pdf-electronic-seal-api/gettingstarted.md
@@ -275,7 +275,7 @@ For security reasons you may wish to confirm the installer's authenticity. To do
 4.  Verify the hash you generated matches the value in the .sha1 file.
 
 ```
-deedd2b91d988fd2300fee47a90069ccc4c51012
+c0bc2ec0eb15dd43d014bd885b3833539f103cf2
 ```
 
 #### Logging

--- a/src/pages/overview/pdf-electronic-seal-api/quickstarts/java/index.md
+++ b/src/pages/overview/pdf-electronic-seal-api/quickstarts/java/index.md
@@ -63,7 +63,7 @@ To complete this guide, you will need:
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
   </properties>
 
   <dependencies>

--- a/src/pages/overview/pdf-extract-api/gettingstarted.md
+++ b/src/pages/overview/pdf-extract-api/gettingstarted.md
@@ -226,7 +226,7 @@ For security reasons you may wish to confirm the installer's authenticity. To do
 4.  Verify the hash you generated matches the value in the .sha1 file.
 
 ```
-deedd2b91d988fd2300fee47a90069ccc4c51012
+c0bc2ec0eb15dd43d014bd885b3833539f103cf2
 ```
 
 #### Logging

--- a/src/pages/overview/pdf-extract-api/quickstarts/java/index.md
+++ b/src/pages/overview/pdf-extract-api/quickstarts/java/index.md
@@ -63,7 +63,7 @@ To complete this guide, you will need:
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
   </properties>
 
   <dependencies>

--- a/src/pages/overview/pdf-services-api/gettingstarted.md
+++ b/src/pages/overview/pdf-services-api/gettingstarted.md
@@ -225,7 +225,7 @@ For security reasons you may wish to confirm the installer's authenticity. To do
 4.  Verify the hash you generated matches the value in the .sha1 file.
 
 ```
-deedd2b91d988fd2300fee47a90069ccc4c51012
+c0bc2ec0eb15dd43d014bd885b3833539f103cf2
 ```
 
 #### Logging

--- a/src/pages/overview/pdf-services-api/quickstarts/java/index.md
+++ b/src/pages/overview/pdf-services-api/quickstarts/java/index.md
@@ -63,7 +63,7 @@ To complete this guide, you will need:
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
   </properties>
 
   <dependencies>

--- a/src/pages/overview/pdf-services-api/releasenotes.md
+++ b/src/pages/overview/pdf-services-api/releasenotes.md
@@ -50,8 +50,8 @@ version.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
-    <pdfservices.sdk.samples.version>3.5.0</pdfservices.sdk.samples.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
+    <pdfservices.sdk.samples.version>3.5.1</pdfservices.sdk.samples.version>
 </properties>
 
 <dependency>
@@ -128,6 +128,12 @@ Minor and Patch releases are backward compatible with the previous release.
 Upgrading to the latest SDK should not break existing applications.
 
 ## Change history
+
+### 3.5.1 (December, 2023: patch release)
+
+| Change  | Language | Description                                                                      |
+|---------|----------|----------------------------------------------------------------------------------|
+| Changed | Java     | Dependent library upgrades and fixed compatibility issues with Spring Boot v3.x. |
 
 ### 3.5.0 (October, 2023: minor release)
 

--- a/src/pages/overview/releasenotes.md
+++ b/src/pages/overview/releasenotes.md
@@ -93,8 +93,8 @@ version.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.5.0</pdfservices.sdk.version>
-    <pdfservices.sdk.samples.version>3.5.0</pdfservices.sdk.samples.version>
+    <pdfservices.sdk.version>3.5.1</pdfservices.sdk.version>
+    <pdfservices.sdk.samples.version>3.5.1</pdfservices.sdk.samples.version>
 </properties>
 
 <dependency>
@@ -172,6 +172,13 @@ Minor and Patch releases are backward compatible with the previous release.
 Upgrading to the latest SDK should not break existing applications.
 
 ## Change history
+
+### 3.5.1 (December, 2023: patch release)
+
+| Change  | Language | Description                                                                      |
+|---------|----------|----------------------------------------------------------------------------------|
+| Changed | Java     | Dependent library upgrades and fixed compatibility issues with Spring Boot v3.x. |
+
 
 ### 3.5.0 (October, 2023: minor release)
 


### PR DESCRIPTION
## Adobe Document Services PDF Service SDK 3.5.1 Release

This release provides the following :-

1. Library upgrades and regular maintenance.
2. Fixed compatibility issues with Spring Boot v3.x.
3. Updated all the samples to use the latest Adobe PDF Services SDK version 3.5.1.
