### PR TITLE
Release notes - PDF Embed API Release - June 2024

### DIFF
--- a/src/pages/overview/pdf-embed-api/gettingstarted.md
+++ b/src/pages/overview/pdf-embed-api/gettingstarted.md
@@ -86,12 +86,6 @@ browsers:
 -   Android - Google Chrome.
 -   iOS - Safari, Google Chrome.
 
-### Support for print PDF
-
-PDF printing is currently not supported in Firefox browser. Clicking on the print PDF button will show a popup asking users to download the file and print using Adobe Acrobat Reader.
-
-![Print Unsupported Error in Firefox](../images/print_unsupported_FF.png)
-
 ## Mobile support
 
 Much of what the PDF Embed API delivers is supported in the mobile

--- a/src/pages/overview/pdf-embed-api/releasenotes.md
+++ b/src/pages/overview/pdf-embed-api/releasenotes.md
@@ -13,8 +13,8 @@ the changes below for each release.
 | ------ | ---------------------------------------------------------------------- |
 | Bug fix | Fixed issue regarding developer console error "Feature can't be enabled or disabled" .   |
 | Bug fix | Fixed issue regarding developer console error "Edit dropin is not loaded".             |
-| Bug fix | Fixed PDF download allowed issue through PDF printing option even when download is disabled in firefox browser.  |
-| New     | PDF Embed API now supports PDF printing in firefox browser. |
+| Bug fix | Fixed PDF download allowed issue through PDF printing option even when download is disabled in Firefox browser.  |
+| New     | PDF Embed API now supports PDF printing in Firefox browser. |
 
 ### May 9, 2024
 | Change | Description                                                            |

--- a/src/pages/overview/pdf-embed-api/releasenotes.md
+++ b/src/pages/overview/pdf-embed-api/releasenotes.md
@@ -8,6 +8,14 @@ the changes below for each release.
 
 ## Change history
 
+### June 27, 2024
+| Change | Description                                                            |
+| ------ | ---------------------------------------------------------------------- |
+| Bug fix | Fixed issue regarding developer console error "Feature can't be enabled or disabled" .   |
+| Bug fix | Fixed issue regarding developer console error "Edit dropin is not loaded".             |
+| Bug fix | Fixed PDF download allowed issue through PDF printing option even when download is disabled in firefox browser.  |
+| New     | PDF Embed API now supports PDF printing in firefox browser. |
+
 ### May 9, 2024
 | Change | Description                                                            |
 | ------ | ---------------------------------------------------------------------- |

--- a/src/pages/overview/pdf-embed-api/releasenotes.md
+++ b/src/pages/overview/pdf-embed-api/releasenotes.md
@@ -11,7 +11,7 @@ the changes below for each release.
 ### June 27, 2024
 | Change | Description                                                            |
 | ------ | ---------------------------------------------------------------------- |
-| Bug fix | Fixed issue regarding developer console error "Feature can't be enabled or disabled" .   |
+| Bug fix | Fixed issue regarding developer console error "Feature can't be enabled or disabled".   |
 | Bug fix | Fixed issue regarding developer console error "Edit dropin is not loaded".             |
 | Bug fix | Fixed PDF download allowed issue through PDF printing option even when download is disabled in Firefox browser.  |
 | New     | PDF Embed API now supports PDF printing in Firefox browser. |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Release notes - PDF Embed API - June 2024
- Remove docs for PDF printing not supported in Firefox.