### PR TITLE
Fix broken ims auth link

### DIFF
--- a/src/pages/apis/index.md
+++ b/src/pages/apis/index.md
@@ -1,6 +1,6 @@
 ---
 title: Adobe PDF Services Open API spec
 description: The OpenAPI spec for Adobe PDF Services API endpoints, parameters, and responses.
-openAPISpec: https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/fix-broken-ims-auth-link/src/pages/resources/openapi.json
+openAPISpec: https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/src/pages/resources/openapi.json
 ---
 -[]

--- a/src/pages/apis/index.md
+++ b/src/pages/apis/index.md
@@ -1,6 +1,6 @@
 ---
 title: Adobe PDF Services Open API spec
 description: The OpenAPI spec for Adobe PDF Services API endpoints, parameters, and responses.
-openAPISpec: https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/src/pages/resources/openapi.json
+openAPISpec: https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/fix-broken-ims-auth-link/src/pages/resources/openapi.json
 ---
 -[]

--- a/src/pages/resources/openapi.json
+++ b/src/pages/resources/openapi.json
@@ -16,7 +16,7 @@
   "tags": [
     {
       "name": "Generate Token",
-      "description": "Creates an access token using client id and client secret. Click <a href=\"https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/ims\">here</a> to refer underlying IMS authentication APIs."
+      "description": "Creates an access token using client id and client secret. Click <a href=\"https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/ims/\">here</a> to refer underlying IMS authentication APIs."
     },
     {
       "name": "Assets",

--- a/src/pages/resources/openapi.json
+++ b/src/pages/resources/openapi.json
@@ -16,7 +16,7 @@
   "tags": [
     {
       "name": "Generate Token",
-      "description": "Creates an access token using client id and client secret. Click <a href=\"https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/IMS/\">here</a> to refer underlying IMS authentication APIs."
+      "description": "Creates an access token using client id and client secret. Click <a href=\"https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/ims\">here</a> to refer underlying IMS authentication APIs."
     },
     {
       "name": "Assets",


### PR DESCRIPTION
## Summary

- Fixes broken link in the "Generate Token" tag description in `openapi.json`
- The link to IMS authentication docs returns a 404 due to a case-sensitivity change in the upstream `adobe-dev-console` repo (AdobeDocs/adobe-dev-console#184 renamed `IMS.md` → `ims.md`)

## Change

**File:** `src/pages/resources/openapi.json`

**Before:**
`https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/IMS/`

**After:**
`https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/ims`

## Root Cause

PR AdobeDocs/adobe-dev-console#184 ("Eds migration", merged 2025-04-01) renamed `IMS.md` to `ims.md` without adding a redirect for the old uppercase path. This broke the link referenced in our OpenAPI spec.

## Test plan

- [ ] Verify the updated URL resolves correctly (no 404)
- [ ] Confirm the "Generate Token" page on https://developer.adobe.com/document-services/docs/apis/#tag/Generate-Token renders the link properly