### PR TITLE
broken links fix

### DIFF
--- a/src/pages/overview/document-generation-api/quickstarts/dotnet/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/dotnet/index.md
@@ -76,7 +76,7 @@ To complete this guide, you will need:
 
 ```
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 4) In your editor, open the directory where you previously copied the credentials and created the `csproj` file. Create a new file, `Program.cs`. 
 

--- a/src/pages/overview/document-generation-api/quickstarts/java/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/java/index.md
@@ -114,7 +114,7 @@ To complete this guide, you will need:
 
 This file will define what dependencies we need and how the application will be built. 
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 4) In your editor, open the directory where you previously copied the credentials, and create a new directory, `src/main/java`. In that directory, create `GeneratePDF.java`. 
 

--- a/src/pages/overview/document-generation-api/quickstarts/nodejs/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/nodejs/index.md
@@ -53,7 +53,7 @@ To complete this guide, you will need:
 
 At this point, we've installed the Node.js SDK for Adobe PDF Services API as a dependency for our project and have copied over our credentials files. 
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 5) In your editor, open the directory where you previously copied the credentials. Create a new file, `generatePDF.js`
 

--- a/src/pages/overview/document-generation-api/quickstarts/python/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/python/index.md
@@ -50,7 +50,7 @@ To complete this guide, you will need:
 
 At this point, we've installed the Python SDK for Adobe PDF Services API as a dependency for our project and have copied over our credentials files.
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 4) In your editor, open the directory where you previously copied the credentials. Create a new file, `generate_pdf.py`.
 

--- a/src/pages/overview/pdf-extract-api/howtos/extract-api.md
+++ b/src/pages/overview/pdf-extract-api/howtos/extract-api.md
@@ -12,9 +12,9 @@ following:
 
 -   The structuredData.json file with the extracted content & PDF
     element structure. See the [JSON
-    schema](../../../../../static/extract-json-output-schema2.json) for a
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json) for a
     description of the default output. (Please refer to the [Styling JSON
-    schema](../../../../../static/extract-json-output-schema-styling-info.json)
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema-styling-info.json)
     for a description of the output when the styling option is enabled.)
 -   A renditions folder(s) containing renditions for each element type
     selected as input. The folder name is either "tables" or "figures"
@@ -26,7 +26,7 @@ following:
 
 The following is a summary of key elements in the extracted JSON (see
 additional descriptions in the [JSON
-schema](../../../../../static/extract-json-output-schema2.json)):
+schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json)):
 
 -   Elements : Ordered list of semantic elements (like headings,
     paragraphs, tables, figures) found in the document, on the basis of

--- a/src/pages/overview/pdf-services-api/howtos/extract-pdf.md
+++ b/src/pages/overview/pdf-services-api/howtos/extract-pdf.md
@@ -12,9 +12,9 @@ following:
 
 -   The structuredData.json file with the extracted content & PDF
     element structure. See the [JSON
-    schema](../../../../../static/extract-json-output-schema2.json) for a
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json) for a
     description of the default output. (Please refer to the [Styling JSON
-    schema](../../../../../static/extract-json-output-schema-styling-info.json)
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema-styling-info.json)
     for a description of the output when the styling option is enabled.)
 -   A renditions folder(s) containing renditions for each element type
     selected as input. The folder name is either "tables" or "figures"
@@ -26,7 +26,7 @@ following:
 
 The following is a summary of key elements in the extracted JSON (see
 additional descriptions in the [JSON
-schema](../../../../../static/extract-json-output-schema2.json)):
+schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json)):
 
 -   Elements : Ordered list of semantic elements (like headings,
     paragraphs, tables, figures) found in the document, on the basis of


### PR DESCRIPTION
Fixed broken static file links after Gatsby to EDS migration.

Files in the static/ folder are not served by EDS. Replaced broken URLs with GitHub raw content URLs for:
- receiptTemplate.docx and receipt.json (4 quickstart pages: Node.js, Python, Java, .NET)
- extract-json-output-schema2.json (PDF Extract API howtos, PDF Services API howtos)
- extract-json-output-schema-styling-info.json (same 2 pages)