### PR TITLE
broken links fix

### DIFF
--- a/src/pages/contributors.json
+++ b/src/pages/contributors.json
@@ -1270,6 +1270,7 @@
     {
       "page": "/overview/pdf-extract-api/howtos/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/119481807?v=4",
         "https://avatars.githubusercontent.com/u/117148595?v=4",
@@ -1279,7 +1280,7 @@
         "https://avatars.githubusercontent.com/u/22152075?v=4",
         "https://avatars.githubusercontent.com/u/393660?v=4"
       ],
-      "lastUpdated": "5/1/2026"
+      "lastUpdated": "6/10/2026"
     },
     {
       "page": "/overview/pdf-extract-api/howtos/api-usage",

--- a/src/pages/contributors.json
+++ b/src/pages/contributors.json
@@ -122,17 +122,19 @@
     {
       "page": "/overview/document-generation-api/quickstarts/dotnet/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/22620821?v=4",
         "https://avatars.githubusercontent.com/u/119481807?v=4",
         "https://avatars.githubusercontent.com/u/32520775?v=4",
         "https://avatars.githubusercontent.com/u/393660?v=4"
       ],
-      "lastUpdated": "5/1/2026"
+      "lastUpdated": "6/5/2026"
     },
     {
       "page": "/overview/document-generation-api/quickstarts/java/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/119481807?v=4",
         "https://avatars.githubusercontent.com/u/4571811?v=4",
@@ -141,11 +143,12 @@
         "https://avatars.githubusercontent.com/u/95292088?v=4",
         "https://avatars.githubusercontent.com/u/393660?v=4"
       ],
-      "lastUpdated": "5/1/2026"
+      "lastUpdated": "6/5/2026"
     },
     {
       "page": "/overview/document-generation-api/quickstarts/nodejs/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/22620821?v=4",
         "https://avatars.githubusercontent.com/u/32520775?v=4",
@@ -153,15 +156,16 @@
         "https://avatars.githubusercontent.com/u/143107745?v=4",
         "https://avatars.githubusercontent.com/u/393660?v=4"
       ],
-      "lastUpdated": "5/1/2026"
+      "lastUpdated": "6/5/2026"
     },
     {
       "page": "/overview/document-generation-api/quickstarts/python/",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/117148595?v=4"
       ],
-      "lastUpdated": "5/1/2026"
+      "lastUpdated": "6/5/2026"
     },
     {
       "page": "/overview/document-generation-api/stylingformattingtags",
@@ -1287,6 +1291,7 @@
     {
       "page": "/overview/pdf-extract-api/howtos/extract-api",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4",
         "https://avatars.githubusercontent.com/u/119481807?v=4",
         "https://avatars.githubusercontent.com/u/117148595?v=4",
@@ -1298,7 +1303,7 @@
         "https://avatars.githubusercontent.com/u/21309021?v=4",
         "https://avatars.githubusercontent.com/u/65894914?v=4"
       ],
-      "lastUpdated": "5/4/2026"
+      "lastUpdated": "6/5/2026"
     },
     {
       "page": "/overview/pdf-extract-api/howtos/pdf-to-markdown-api",
@@ -1489,9 +1494,10 @@
     {
       "page": "/overview/pdf-services-api/howtos/extract-pdf",
       "avatars": [
+        "https://avatars.githubusercontent.com/u/276200381?v=4",
         "https://avatars.githubusercontent.com/u/14320591?v=4"
       ],
-      "lastUpdated": "5/26/2026"
+      "lastUpdated": "6/5/2026"
     },
     {
       "page": "/overview/pdf-services-api/howtos/import-pdf-form-data",

--- a/src/pages/overview/document-generation-api/quickstarts/dotnet/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/dotnet/index.md
@@ -76,7 +76,7 @@ To complete this guide, you will need:
 
 ```
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 4) In your editor, open the directory where you previously copied the credentials and created the `csproj` file. Create a new file, `Program.cs`. 
 

--- a/src/pages/overview/document-generation-api/quickstarts/java/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/java/index.md
@@ -114,7 +114,7 @@ To complete this guide, you will need:
 
 This file will define what dependencies we need and how the application will be built. 
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 4) In your editor, open the directory where you previously copied the credentials, and create a new directory, `src/main/java`. In that directory, create `GeneratePDF.java`. 
 

--- a/src/pages/overview/document-generation-api/quickstarts/nodejs/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/nodejs/index.md
@@ -53,7 +53,7 @@ To complete this guide, you will need:
 
 At this point, we've installed the Node.js SDK for Adobe PDF Services API as a dependency for our project and have copied over our credentials files. 
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 5) In your editor, open the directory where you previously copied the credentials. Create a new file, `generatePDF.js`
 

--- a/src/pages/overview/document-generation-api/quickstarts/python/index.md
+++ b/src/pages/overview/document-generation-api/quickstarts/python/index.md
@@ -50,7 +50,7 @@ To complete this guide, you will need:
 
 At this point, we've installed the Python SDK for Adobe PDF Services API as a dependency for our project and have copied over our credentials files.
 
-Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://developer.adobe.com/document-services/docs/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://developer.adobe.com/document-services/docs/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
+Our application will take a Word document, `receiptTemplate.docx` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receiptTemplate.docx)), and combine it with data in a JSON file, `receipt.json` (downloadable from [here](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/receipt.json)), to be sent to the Acrobat Services API and generate a receipt PDF.
 
 4) In your editor, open the directory where you previously copied the credentials. Create a new file, `generate_pdf.py`.
 

--- a/src/pages/overview/pdf-extract-api/howtos/extract-api.md
+++ b/src/pages/overview/pdf-extract-api/howtos/extract-api.md
@@ -12,9 +12,9 @@ following:
 
 -   The structuredData.json file with the extracted content & PDF
     element structure. See the [JSON
-    schema](../../../../../static/extract-json-output-schema2.json) for a
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json) for a
     description of the default output. (Please refer to the [Styling JSON
-    schema](../../../../../static/extract-json-output-schema-styling-info.json)
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema-styling-info.json)
     for a description of the output when the styling option is enabled.)
 -   A renditions folder(s) containing renditions for each element type
     selected as input. The folder name is either "tables" or "figures"
@@ -26,7 +26,7 @@ following:
 
 The following is a summary of key elements in the extracted JSON (see
 additional descriptions in the [JSON
-schema](../../../../../static/extract-json-output-schema2.json)):
+schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json)):
 
 -   Elements : Ordered list of semantic elements (like headings,
     paragraphs, tables, figures) found in the document, on the basis of

--- a/src/pages/overview/pdf-extract-api/howtos/index.md
+++ b/src/pages/overview/pdf-extract-api/howtos/index.md
@@ -23,7 +23,7 @@ For code examples illustrating other PDF actions including those below, see the 
 
 ## How It Works
 
-PDF Extract uses AI/ML technology to identify and categorize the various objects within documents – such as paragraphs, lists, headings, tables, and images – and extract the text, formatting, and associated document structural information which is then delivered in a resulting JSON file. Extracted table data can optionally be delivered within .CSV or .XLSX files, and extracted images are delivered as .PNG files. For additional information, please refer to the [PDF Extract API white paper](https://www.adobe.com/content/dam/cc/en/trust-center/ungated/whitepapers/dx/Adobe-PDF-Extract-API-Technical-Brief.pdf).
+PDF Extract uses AI/ML technology to identify and categorize the various objects within documents – such as paragraphs, lists, headings, tables, and images – and extract the text, formatting, and associated document structural information which is then delivered in a resulting JSON file. Extracted table data can optionally be delivered within .CSV or .XLSX files, and extracted images are delivered as .PNG files. For additional information, please refer to the [PDF Extract API white paper](https://www.adobe.com/cc-shared/assets/pdf/trust-center/ungated/whitepapers/doc-cloud/adobe-document-services-security-overview.pdf).
 
 ## Custom timeout configuration
 

--- a/src/pages/overview/pdf-services-api/howtos/extract-pdf.md
+++ b/src/pages/overview/pdf-services-api/howtos/extract-pdf.md
@@ -12,9 +12,9 @@ following:
 
 -   The structuredData.json file with the extracted content & PDF
     element structure. See the [JSON
-    schema](../../../../../static/extract-json-output-schema2.json) for a
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json) for a
     description of the default output. (Please refer to the [Styling JSON
-    schema](../../../../../static/extract-json-output-schema-styling-info.json)
+    schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema-styling-info.json)
     for a description of the output when the styling option is enabled.)
 -   A renditions folder(s) containing renditions for each element type
     selected as input. The folder name is either "tables" or "figures"
@@ -26,7 +26,7 @@ following:
 
 The following is a summary of key elements in the extracted JSON (see
 additional descriptions in the [JSON
-schema](../../../../../static/extract-json-output-schema2.json)):
+schema](https://raw.githubusercontent.com/AdobeDocs/pdfservices-api-documentation/main/static/extract-json-output-schema2.json)):
 
 -   Elements : Ordered list of semantic elements (like headings,
     paragraphs, tables, figures) found in the document, on the basis of


### PR DESCRIPTION
Fixed broken static file links after Gatsby to EDS migration.

Files in the static/ folder are not served by EDS. Replaced broken URLs with GitHub raw content URLs for:
- receiptTemplate.docx and receipt.json (4 quickstart pages: Node.js, Python, Java, .NET)
- extract-json-output-schema2.json (PDF Extract API howtos, PDF Services API howtos)
- extract-json-output-schema-styling-info.json (same 2 pages)